### PR TITLE
Fix error when file is not saved

### DIFF
--- a/lib/auto-soft-wrap.coffee
+++ b/lib/auto-soft-wrap.coffee
@@ -25,7 +25,8 @@ module.exports = AutoSoftWrap =
 		if item?
 			if item.getPath?
 				path = item.getPath()
-				extension = path.substr(path.lastIndexOf("."))
-				fileTypes = atom.config.get("auto-soft-wrap.softWrapFileTypes")
-				if (extension in fileTypes)
-					item.setSoftWrapped(true)
+				if path?
+					extension = path.substr(path.lastIndexOf("."))
+					fileTypes = atom.config.get("auto-soft-wrap.softWrapFileTypes")
+					if (extension in fileTypes)
+						item.setSoftWrapped(true)


### PR DESCRIPTION
When a new file is made and has not been saved, `item.getPath()` will return undefined. This change will check if `path` is undefined, and ignore the pane if it is.

Fixes issue #1 
